### PR TITLE
test: pin postgres version to 14 temporarily

### DIFF
--- a/resource_binding_user_test.go
+++ b/resource_binding_user_test.go
@@ -54,7 +54,7 @@ var _ = Describe("SSL Postgres Bindings", func() {
 			"-e", fmt.Sprintf("POSTGRES_DB=%s", defaultDatabase),
 			"-p", fmt.Sprintf("%d:5432", port),
 			"--mount", "source=ssl_postgres,destination=/mnt",
-			"-t", "postgres",
+			"-t", "postgres:14",
 			"-c", "config_file=/mnt/pgconf/postgresql.conf",
 			"-c", "hba_file=/mnt/pgconf/pg_hba.conf",
 		)


### PR DESCRIPTION
Postgres 15 has been released and it includes changes to default permissions that break our tests. Since this version, only database owners have CREATE permissions on public schema.
This change has to be reverted once we ensure the provider is compatible with the new version and change our tests accordingly

[#183556143](https://www.pivotaltracker.com/story/show/183556143)

### Checklist:

~~* [ ] Have you added Release Notes in the docs repository?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
