### PR TITLE
chore: add context to error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ fmt: ## format the code
 
 .PHONY: ginkgo
 ginkgo: ## run the tests with Ginkgo
-	go run github.com/onsi/ginkgo/v2/ginkgo -r
+	go run github.com/onsi/ginkgo/v2/ginkgo -r -v
 
 .PHONY: version
 version:

--- a/csbpg/data_owner_role.go
+++ b/csbpg/data_owner_role.go
@@ -9,26 +9,29 @@ import (
 )
 
 func createDataOwnerRole(tx *sql.Tx, cf connectionFactory) error {
+	log.Println("[DEBUG] ENTRY createDataOwnerRole()")
+	defer log.Println("[DEBUG] EXIT createDataOwnerRole()")
+
 	exists, err := roleExists(tx, cf.dataOwnerRole)
 	if err != nil {
-		return err
+		return fmt.Errorf("checking whether dataowner exists: %w", err)
 	}
 
 	if !exists {
 		log.Println("[DEBUG] data owner role does not exist - creating")
-		_, err = tx.Exec(fmt.Sprintf("CREATE ROLE %s WITH NOLOGIN", pq.QuoteIdentifier(cf.dataOwnerRole)))
-
-		if err != nil {
-			return err
+		if _, err := tx.Exec(fmt.Sprintf("CREATE ROLE %s WITH NOLOGIN", pq.QuoteIdentifier(cf.dataOwnerRole))); err != nil {
+			return fmt.Errorf("creating dataowner role: %w", err)
 		}
 	}
 
 	log.Println("[DEBUG] granting data owner role")
-	_, err = tx.Exec(fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s TO %s", pq.QuoteIdentifier(cf.database), pq.QuoteIdentifier(cf.dataOwnerRole)))
-	if err != nil {
-		return err
+	if _, err := tx.Exec(fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s TO %s", pq.QuoteIdentifier(cf.database), pq.QuoteIdentifier(cf.dataOwnerRole))); err != nil {
+		return fmt.Errorf("granting database privilidge to datawoner role: %w", err)
 	}
 
-	_, err = tx.Exec(fmt.Sprintf("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %s", pq.QuoteIdentifier(cf.dataOwnerRole)))
-	return err
+	if _, err := tx.Exec(fmt.Sprintf("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %s", pq.QuoteIdentifier(cf.dataOwnerRole))); err != nil {
+		return fmt.Errorf("granting table privilidge to datawoner role: %w", err)
+	}
+
+	return nil
 }

--- a/csbpg_suite_test.go
+++ b/csbpg_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,11 +57,12 @@ func createVolume(fixtureName string) {
 }
 
 func mustRun(command ...string) {
+	GinkgoWriter.Printf("running: %s\n", strings.Join(command, " "))
 	start, err := gexec.Start(exec.Command(
 		command[0], command[1:]...,
 	), GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
-	Eventually(start).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(gexec.Exit(0))
+	Eventually(start).WithTimeout(time.Minute).WithPolling(time.Second).Should(gexec.Exit(0))
 }
 
 func getPWD() string {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-
 	"github.com/cloudfoundry/terraform-provider-csbpg/csbpg"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {

--- a/resource_binding_user_test.go
+++ b/resource_binding_user_test.go
@@ -58,6 +58,7 @@ var _ = Describe("SSL Postgres Bindings", func() {
 			"-c", "config_file=/mnt/pgconf/postgresql.conf",
 			"-c", "hba_file=/mnt/pgconf/pg_hba.conf",
 		)
+		GinkgoWriter.Printf("running: %s\n", cmd)
 		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
When an error occurs, it's not always clear which line of code the error came from. This commit add some context to error messages so that it's easier to work out which line they came from.

[#184593839](https://www.pivotaltracker.com/story/show/184593839)
