### PR TITLE
feat: support Postgres15

### DIFF
--- a/csbpg/data_owner_role.go
+++ b/csbpg/data_owner_role.go
@@ -29,6 +29,11 @@ func createDataOwnerRole(tx *sql.Tx, cf connectionFactory) error {
 		return fmt.Errorf("granting database privilege to datawoner role: %w", err)
 	}
 
+	log.Println("[DEBUG] granting permission on schema public to data owner role (required since postgres 15)")
+	if _, err := tx.Exec(fmt.Sprintf("GRANT ALL PRIVILEGES ON SCHEMA PUBLIC TO %s", pq.QuoteIdentifier(cf.dataOwnerRole))); err != nil {
+		return fmt.Errorf("granting all privileges on schema public to datawoner role: %w", err)
+	}
+
 	if _, err := tx.Exec(fmt.Sprintf("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %s", pq.QuoteIdentifier(cf.dataOwnerRole))); err != nil {
 		return fmt.Errorf("granting table privilege to datawoner role: %w", err)
 	}


### PR DESCRIPTION
[#183626592]

Postgres15 changed default permissions for the public schema which breaks the existing binding logic.

We believe adopting this solution doesn't go against  [official postgres security best patterns and practices](https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PATTERNS) because the way CSB operates matches the following use-case:

> It is acceptable only when the database has a single user or a few **mutually-trusting users**.

### Checklist:

* [ ] Have you added Release Notes in the docs repository?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
