### PR TITLE
fix: user binding creation in GCP

### DIFF
--- a/csbpg/resource_binding_user.go
+++ b/csbpg/resource_binding_user.go
@@ -108,6 +108,9 @@ func resourceBindingUserCreate(ctx context.Context, d *schema.ResourceData, m an
 		if _, err := tx.Exec(fmt.Sprintf("CREATE ROLE %s WITH LOGIN PASSWORD %s INHERIT IN ROLE %s", pq.QuoteIdentifier(username), safeQuote(password), pq.QuoteIdentifier(cf.dataOwnerRole))); err != nil {
 			return diag.Errorf("creating binding role: %s", err)
 		}
+		if _, err = tx.Exec(fmt.Sprintf("GRANT %s TO %s", pq.QuoteIdentifier(username), pq.QuoteIdentifier(cf.username))); err != nil {
+			return diag.Errorf("grant admin the right to impersonate new role and manipulate its objects: %s", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
[#185431677]

Postgres superuser (`cf.username`) in GCP can't
manipulate other users' objects by default.

Current implementation, at binding creation time
tries to GRANT ALL PERMISSIONS on any tables
in the PUBLIC schema to dataOwnerRole while
logged as the `cf.username`.

Such operation fails and prevents the creation of
new bindings. To workaround this an operator
would need to login as the table owner and explicitly GRANT dataOwnerRole or `cf.username` permissions
to the table.

This commit fixes the issue for any new binding, but existing bindings can still cause this kind of issues. Recreating existing bindings is recommended.

### Checklist:

* [ ] Have you added Release Notes in the docs repository?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
