### PR TITLE
fix: roles' inability to administer themselves in pg15

### DIFF
--- a/csbpg/resource_binding_user.go
+++ b/csbpg/resource_binding_user.go
@@ -198,6 +198,18 @@ func resourceBindingUserDelete(ctx context.Context, d *schema.ResourceData, m an
 func sqlUserDelete(ctx context.Context, bindingUser, bindingUserPassword string, m any) diag.Diagnostics {
 	cf := m.(connectionFactory)
 
+	userDb, err := cf.ConnectAsUser(bindingUser, bindingUserPassword)
+	if err != nil {
+		return diag.Errorf("connecting as binding user: %s", err)
+	}
+	defer func() {
+		_ = userDb.Close()
+	}()
+
+	if _, err := userDb.ExecContext(ctx, fmt.Sprintf("GRANT %s TO %s", pq.QuoteIdentifier(bindingUser), pq.QuoteIdentifier(cf.username))); err != nil {
+		return diag.Errorf("granting admin user access to binding user: %s", err)
+	}
+
 	db, err := cf.ConnectAsAdmin()
 	if err != nil {
 		return diag.Errorf("connecting as admin: %s", err)


### PR DESCRIPTION
PostgreSQL 15 removed the ability of a role to administer itself
https://github.com/postgres/postgres/commit/79de9842ab03259325ee4055fb0a7ebd2e4372ff

Apparently, CSB admin user has enough permissions to perform this
operation so we can simply remove the ConnectAsUser steps
https://github.com/cloudfoundry/terraform-provider-csbpg/blob/593bde1534dbf181ee0b704e3f8e9b2903240405/csbpg/resource_binding_user.go#L217

Notice how there is an equivalent instruction in sqlUserCreate.
https://github.com/cloudfoundry/terraform-provider-csbpg/blob/593bde1534dbf181ee0b704e3f8e9b2903240405/csbpg/resource_binding_user.go#L132

You could ask: "Then what's the purpose of duplicating it here?"

Because of broker upgrades.
Currently, we can't determine if an existing binding was created
with the current version of the code or an previous one which
didn't include this GRANT instruction.

It would be great to be able to recreate existing users and roles
when upgrading the broker, until then we need this as a safety net

### Checklist:

* ~[ ] Have you added Release Notes in the docs repository?~ (implementation detail)
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
